### PR TITLE
Arreglo division por 0

### DIFF
--- a/game.py
+++ b/game.py
@@ -242,7 +242,12 @@ class Game:
             int(self.face_bottom_y*self.webcam.height()) - int(self.face_top_y*self.webcam.height())
         ))
         only_face_surf.blit(face_surf, (0,0), face_rect)
-        face_ratio = only_face_surf.get_rect().height / only_face_surf.get_rect().width
+
+        height = only_face_surf.get_rect().height
+        width = only_face_surf.get_rect().width
+        if width == 0:
+            width = 1        
+        face_ratio =  height / width
         face_area_width = 130
         face_area_height = face_area_width * face_ratio
         if (face_area_height > self.max_face_surf_height):


### PR DESCRIPTION
en ciertos momentos cuando se inicia el juego se cierra porque obtiene una division por 0, para prevenirlo se valida antes de realizar la division el valor y si es 0 entonces e cambia por un 1